### PR TITLE
:notebook: add promo-chat-{user|assistant}-message-display

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ using tailwindcss, use an `@apply` directive.
 #promo-chat-input-only-container
 #promo-chat-text-input
 #promo-chat-input-submit-button
+#promo-chat-user-message-display
+#promo-chat-assistant-message-display
 ```
 
 ## Support

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -23,7 +23,10 @@ export function Messages({ latestMessages }: MessagesProps) {
             className="mb-2 text-right"
             id={`promo-chat-user-message-${index}`}
           >
-            <p className="inline-block rounded-lg bg-blue-700 px-4 py-2 text-white">
+            <p
+              id="promo-chat-user-message-display"
+              className="inline-block rounded-lg bg-blue-700 px-4 py-2 text-white"
+            >
               {message}
             </p>
           </div>
@@ -33,7 +36,10 @@ export function Messages({ latestMessages }: MessagesProps) {
             className="mb-2"
             id={`promo-chat-assistant-message-${index}`}
           >
-            <p className="inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700">
+            <p
+              id="promo-chat-assistant-message-display"
+              className="inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700"
+            >
               {message}
             </p>
           </div>


### PR DESCRIPTION
This merge adds two missing css ids for customizing style of the actual user and assistant messages.

Those can now be customized via 
- `promo-chat-user-message-display`, and
- `promo-chat-assistant-message-display`.

An example to customize these in one's tailwindcss configuration might be:

```css
#promo-chat-user-message-display {
  @apply inline-block rounded-lg bg-indigo-200 px-4 py-2 text-indigo-900
}
#promo-chat-assistant-message-display {
  @apply inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700
}
```