### PR TITLE
:wrench: :white_check_mark: upgrade test node version to 18

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ stages:
   - test
 unit-test:
   stage: unit-test
-  image: node:16
+  image: node:18
   tags:
     - cicd
     - test


### PR DESCRIPTION
This upgrades the node test version to 18 from 16.