### PR TITLE
Feature/add styling to markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Use your favorite package manager to rock installation of `promo-chat`.
 ### Yarn
 
 ```
-yarn add @tincre/promo-chat@latest @tincre/promo-types@latest # -D if you want this as a dev dep
+yarn add @tincre/promo-chat@latest @tincre/promo-types@latest @tailwindcss/typography markdown-to-jsx # -D if you want this as a dev dep
 ```
 
 ### Npm
 
 ```
-npm install @tincre/promo-chat@latest @tincre/promo-types@latest # --save-dev if you want it as a dev dep
+npm install @tincre/promo-chat@latest @tincre/promo-types@latest @tailwindcss/typography markdown-to-jsx # --save-dev if you want it as a dev dep
 ```
 
 ### Tailwindcss Setup

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@ A chat component for Tincre [Promo](https://tincre.dev/promo). Use it in conjunc
   - [Installation](#installation)
     - [Yarn](#yarn)
     - [Npm](#npm)
+    - [Tailwindcss Setup](#tailwindcss-setup)
     - [Environment variables](#environment-variables)
       - [`.env.local` Example](#envlocal-example)
     - [Usage](#usage)
+      - [Usage example](#usage-example)
+    - [Backend functionality](#backend-functionality)
+    - [Customize styling](#customize-styling)
+      - [Tailwindcss Typography Extras](#tailwindcss-typography-extras)
+    - [Full CSS Customization Example](#full-css-customization-example)
   - [Support](#support)
   - [License](#license)
   - [Development](#development)
@@ -109,7 +115,7 @@ A full example:
 > _Note: `token` above is only used if the `useRecaptcha` property on
 > `PromoChat` component rendering is `true`._
 
-### Customize the look & feel
+### Customize styling
 
 Just add the following classes to your tailwindcss or regular css. If
 using tailwindcss, use an `@apply` directive.
@@ -132,6 +138,28 @@ using tailwindcss, use an `@apply` directive.
 #promo-chat-assistant-message-display
 #promo-chat-error-message-display
 ```
+
+#### Tailwindcss Typography Extras
+
+Blockquotes in the default [@tailwindcss/typography]() component have `"` around
+them. If you'd like to remove those for your chat component, simply extend the
+`typography` directive within your `tailwind.config.js` file. For example:
+
+```js
+      typography: {
+        'quoteless-promo-chat': {
+          css: {
+            'blockquote p:first-of-type::before': { content: 'none' },
+            'blockquote p:first-of-type::after': { content: 'none' },
+          },
+        },
+      },
+
+```
+
+The className `prose-quoteless-promo-chat` will automatically be activated.
+In fact, you can make this blockquote do whatever you'd like and we'll render
+it.
 
 ### Full CSS Customization Example
 

--- a/example/nextjs/package.json
+++ b/example/nextjs/package.json
@@ -20,6 +20,7 @@
     "@nastyox/rando.js": "^2.0.5",
     "@react-icons/all-files": "^4.1.0",
     "@reactour/tour": "^3.2.1",
+    "@tailwindcss/typography": "^0.5.10",
     "@tincre/promo-button": "^0.7.2",
     "@tincre/promo-dashboard": "^0.11.3",
     "@tincre/promo-node": "^0.1.1",

--- a/example/nextjs/tailwind.config.js
+++ b/example/nextjs/tailwind.config.js
@@ -28,5 +28,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/typography')],
 };

--- a/example/nextjs/tailwind.config.js
+++ b/example/nextjs/tailwind.config.js
@@ -26,6 +26,14 @@ module.exports = {
       animation: {
         wave: 'wave 3.0s infinite',
       },
+      typography: {
+        'quoteless-promo-chat': {
+          css: {
+            'blockquote p:first-of-type::before': { content: 'none' },
+            'blockquote p:first-of-type::after': { content: 'none' },
+          },
+        },
+      },
     },
   },
   plugins: [require('@tailwindcss/typography')],

--- a/example/nextjs/yarn.lock
+++ b/example/nextjs/yarn.lock
@@ -255,6 +255,16 @@
   dependencies:
     tslib "^2.4.0"
 
+"@tailwindcss/typography@^0.5.10":
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.10.tgz#2abde4c6d5c797ab49cf47610830a301de4c1e0a"
+  integrity sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@tincre/promo-button@^0.7.2":
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/@tincre/promo-button/-/promo-button-0.7.6.tgz#cffdc133bfa5a43e2de20931e0e576673740a32d"
@@ -1909,6 +1919,11 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
 lodash.includes@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
@@ -2519,6 +2534,14 @@ postcss-nested@^6.0.1:
   integrity sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==
   dependencies:
     postcss-selector-parser "^6.0.11"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss-selector-parser@^6.0.11:
   version "6.0.13"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "peerDependencies": {
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": ">=2.0",
+    "@tailwindcss/typography": "^0.5.10",
     "@tincre/promo-types": "^0.0.2",
     "markdown-to-jsx": "^7.3.2",
     "react": ">=16",
@@ -60,6 +61,7 @@
     "@heroicons/react": "^2.0.12",
     "@nastyox/rando.js": "^2.0.5",
     "@size-limit/preset-small-lib": "^8.1.0",
+    "@tailwindcss/typography": "^0.5.10",
     "@testing-library/react": "^13.4.0",
     "@tincre/promo-types": "^0.0.2",
     "@tsconfig/create-react-app": "^1.0.2",

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -6,6 +6,7 @@
  */
 import Markdown from 'markdown-to-jsx';
 import { ReactNode } from 'react';
+import { PromoChatA } from './PromoChatA';
 
 export type MessagesProps = {
   latestMessages: MessageType[];
@@ -15,15 +16,7 @@ export type MessageType = {
   message: string;
   role: 'assistant' | 'system' | 'user';
 };
-type BetterAProps = {
-  children?: ReactNode;
-  className?: string;
-  target?: string;
-  rel?: string;
-};
-function BetterA({ children, ...props }: BetterAProps) {
-  return <a {...props}>{children}</a>;
-}
+
 export function Messages({ latestMessages, responseError }: MessagesProps) {
   return (
     <>
@@ -43,9 +36,10 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
                 options={{
                   overrides: {
                     a: {
-                      component: BetterA,
+                      component: PromoChatA,
                       props: {
-                        className: 'transition duration-300 hover:delay-300 hover:font-bold',
+                        className:
+                          'transition duration-300 hover:delay-300 hover:font-bold',
                         target: '_blank',
                         rel: 'noopener noreferrer',
                       },
@@ -71,7 +65,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
                 options={{
                   overrides: {
                     a: {
-                      component: BetterA,
+                      component: PromoChatA,
                       props: {
                         className: 'hover:font-bold',
                       },
@@ -100,7 +94,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
                 options={{
                   overrides: {
                     a: {
-                      component: BetterA,
+                      component: PromoChatA,
                       props: {
                         className: 'hover:font-bold',
                       },

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -5,6 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 import Markdown from 'markdown-to-jsx';
+import { ReactNode } from 'react';
 
 export type MessagesProps = {
   latestMessages: MessageType[];
@@ -14,7 +15,15 @@ export type MessageType = {
   message: string;
   role: 'assistant' | 'system' | 'user';
 };
-
+type BetterAProps = {
+  children?: ReactNode;
+  className?: string;
+  target?: string;
+  rel?: string;
+};
+function BetterA({ children, ...props }: BetterAProps) {
+  return <a {...props}>{children}</a>;
+}
 export function Messages({ latestMessages, responseError }: MessagesProps) {
   return (
     <>
@@ -30,7 +39,22 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
               id="promo-chat-user-message-display"
               className="prose prose-quoteless-promo-chat inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
             >
-              <Markdown>{message}</Markdown>
+              <Markdown
+                options={{
+                  overrides: {
+                    a: {
+                      component: BetterA,
+                      props: {
+                        className: 'transition duration-300 hover:delay-300 hover:font-bold',
+                        target: '_blank',
+                        rel: 'noopener noreferrer',
+                      },
+                    },
+                  },
+                }}
+              >
+                {message}
+              </Markdown>
             </p>
           </div>
         ) : (
@@ -43,7 +67,20 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
               id="promo-chat-assistant-message-display"
               className="prose prose-quoteless-promo-chat inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700 select-all"
             >
-              <Markdown>{message}</Markdown>
+              <Markdown
+                options={{
+                  overrides: {
+                    a: {
+                      component: BetterA,
+                      props: {
+                        className: 'hover:font-bold',
+                      },
+                    },
+                  },
+                }}
+              >
+                {message}
+              </Markdown>
             </p>
           </div>
         );
@@ -59,7 +96,18 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
               id="promo-chat-error-message-display"
               className="prose prose-quoteless-promo-chat inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
             >
-              <Markdown>{`⚠️ ${responseError} ⚠️`}</Markdown>
+              <Markdown
+                options={{
+                  overrides: {
+                    a: {
+                      component: BetterA,
+                      props: {
+                        className: 'hover:font-bold',
+                      },
+                    },
+                  },
+                }}
+              >{`⚠️ ${responseError} ⚠️`}</Markdown>
             </p>
           </div>
         ) : null}

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -28,7 +28,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
           >
             <p
               id="promo-chat-user-message-display"
-              className="prose inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
+              className="prose prose-quoteless-promo-chat inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
             >
               <Markdown>{message}</Markdown>
             </p>
@@ -41,7 +41,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
           >
             <p
               id="promo-chat-assistant-message-display"
-              className="prose inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700 select-all"
+              className="prose prose-quoteless-promo-chat inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700 select-all"
             >
               <Markdown>{message}</Markdown>
             </p>
@@ -57,7 +57,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
           >
             <p
               id="promo-chat-error-message-display"
-              className="prose inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
+              className="prose prose-quoteless-promo-chat inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
             >
               <Markdown>{`⚠️ ${responseError} ⚠️`}</Markdown>
             </p>

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -28,7 +28,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
           >
             <p
               id="promo-chat-user-message-display"
-              className="inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
+              className="prose inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
             >
               <Markdown>{message}</Markdown>
             </p>
@@ -41,7 +41,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
           >
             <p
               id="promo-chat-assistant-message-display"
-              className="inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700 select-all"
+              className="prose inline-block rounded-lg bg-gray-200 px-4 py-2 text-gray-700 select-all"
             >
               <Markdown>{message}</Markdown>
             </p>
@@ -57,7 +57,7 @@ export function Messages({ latestMessages, responseError }: MessagesProps) {
           >
             <p
               id="promo-chat-error-message-display"
-              className="inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
+              className="prose inline-block rounded-lg bg-blue-700 px-4 py-2 text-white select-all"
             >
               <Markdown>{`⚠️ ${responseError} ⚠️`}</Markdown>
             </p>

--- a/src/components/PromoChatA.tsx
+++ b/src/components/PromoChatA.tsx
@@ -1,0 +1,12 @@
+import React, { ReactNode } from 'react';
+
+export type PromoChatA = {
+  children?: ReactNode;
+  className?: string;
+  target?: string;
+  rel?: string;
+};
+
+export function PromoChatA({ children, ...props }: PromoChatA) {
+  return <a {...props}>{children}</a>;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1520,6 +1520,16 @@
     "@size-limit/file" "8.2.6"
     size-limit "8.2.6"
 
+"@tailwindcss/typography@^0.5.10":
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/typography/-/typography-0.5.10.tgz#2abde4c6d5c797ab49cf47610830a301de4c1e0a"
+  integrity sha512-Pe8BuPJQJd3FfRnm6H0ulKIGoMEQS+Vq01R6M5aCrFB/ccR/shT+0kXLjouGC1gFLm9hopTFN+DMP0pfwRWzPw==
+  dependencies:
+    lodash.castarray "^4.4.0"
+    lodash.isplainobject "^4.0.6"
+    lodash.merge "^4.6.2"
+    postcss-selector-parser "6.0.10"
+
 "@testing-library/dom@^8.5.0":
   version "8.20.1"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.1.tgz#2e52a32e46fc88369eef7eef634ac2a192decd9f"
@@ -2582,6 +2592,11 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+cssesc@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 cssom@^0.4.4:
   version "0.4.4"
@@ -4763,10 +4778,20 @@ lodash-es@^4.17.21:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
   integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
+lodash.castarray@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz#c02513515e309daddd4c24c60cfddcf5976d9115"
+  integrity sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==
+
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
 
 lodash.memoize@4.x:
   version "4.1.2"
@@ -5249,6 +5274,14 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+postcss-selector-parser@6.0.10:
+  version "6.0.10"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz#79b61e2c0d1bfc2602d549e11d0876256f8df88d"
+  integrity sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
 postcss@^8.4.20, postcss@^8.4.31:
   version "8.4.31"
@@ -6275,7 +6308,7 @@ url-parse@^1.5.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==


### PR DESCRIPTION
This adds default styling for markdown returned or used in the chat button. It leverages the [@tailwindcss/typography](https://tailwindcss.com/docs/typography-plugin) plugin to get the job done.